### PR TITLE
fix: get next version from changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,15 +20,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Git version
-        id: version
-        uses: codacy/git-version@2.4.0
-        with:
-          release-branch: "main"
       - name: Get Frameworks versions
         id: frameworks_versions
         run: |
           git checkout main
+          export NEXT_VERSION=$(awk 'NR==1{sub(/^## /, ""); print}' Changelog.md)
+          echo "{NEXT_VERSION}={$NEXT_VERSION}" >> $GITHUB_OUTPUT
           export TIKI_SDK_FLUTTER_VERSION=$(grep -oiP "download\/\d?\d\.\d?\d\.\d?\d" Package.swift | awk -F/ 'NR==1{print $2}')
           echo "{TIKI_SDK_FLUTTER_VERSION}={$TIKI_SDK_FLUTTER_VERSION}" >> $GITHUB_OUTPUT
           echo "TIKI_SDK_FLUTTER_VERSION:$TIKI_SDK_FLUTTER_VERSION"
@@ -54,15 +51,13 @@ jobs:
           git config --global user.name 'GH Release action'
           git config --global user.email 'gh-release-action@mytiki'
           git add Package.swift
-          git commit -m "${{ steps.version.outputs.version }}"
-      - name: Create a new tag
-        run: |
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
+          git commit -m "Release ${{ steps.frameworks_versions.outputs.NEXT_VERSION }}"
+          git tag ${{ steps.frameworks_versions.outputs.NEXT_VERSION }}
+          git push origin ${{ steps.frameworks_versions.outputs.NEXT_VERSION }}
       - name: Create a Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{steps.version.outputs.version }}
+          tag: ${{ steps.frameworks_versions.outputs.NEXT_VERSION }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,5 @@ jobs:
 
       - name: Next release
         run: |
-          export next=$(awk 'NR==1{sub(/^## /, ""); print}' Changelog.md
-)
+          export next=$(awk 'NR==1{sub(/^## /, ""); print}' Changelog.md)
           echo "Next release: ${{next}}""

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,4 +32,4 @@ jobs:
       - name: Next release
         run: |
           export next=$(awk 'NR==1{sub(/^## /, ""); print}' Changelog.md)
-          echo "Next release: ${{next}}""
+          echo "Next release: $next"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,3 +28,9 @@ jobs:
         run: |
           cd IntegrationTests
           xcodebuild test -project IntegrationTests.xcodeproj -scheme IntegrationTestsRunner -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'
+
+      - name: Next release
+        run: |
+          export next=$(awk 'NR==1{sub(/^## /, ""); print}' Changelog.md
+)
+          echo "Next release: ${{next}}""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1
+
+* 
+## 1.1.0
+
+*
 ## 1.0.2
 
 * update release workflow


### PR DESCRIPTION
Fix the release action tag generation.

Gets the next tag from the changelog.

closes #133
closes #134