### PR TITLE
fix: permissions check in Settings and OfferFlow

### DIFF
--- a/Sources/TikiSdk/Ui/EndingError.swift
+++ b/Sources/TikiSdk/Ui/EndingError.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct EndingError: View{
     
     @Environment(\.colorScheme) private var colorScheme
-    var pendingPermissions: String
+    @Binding var pendingPermissions: [PermissionType]?
+    var onAuthorized: () -> Void
     
     var body: some View {
         Ending(
@@ -18,7 +19,7 @@ struct EndingError: View{
                         Text("To proceed, allow ")
                             .font(.custom(TikiSdk.theme(colorScheme).fontRegular, size: 18))
                             .foregroundColor(Color(.black).opacity(0.6))
-                        Text("\(pendingPermissions).").font(.custom(TikiSdk.theme(colorScheme).fontRegular, size: 18))
+                        Text("\(getPendingPermissionsNames()).").font(.custom(TikiSdk.theme(colorScheme).fontRegular, size: 18))
                             .font(.custom(TikiSdk.theme(colorScheme).fontRegular, size: 18))
                             .foregroundColor(Color(.black).opacity(0.6))
                             .underline()
@@ -34,6 +35,33 @@ struct EndingError: View{
                     }
                 }
             )
-        )
+        ).onAppear{
+            requestPendingPermissions()
+        }
+    }
+    
+    
+    func getPendingPermissionsNames() -> String{
+        if(pendingPermissions!.count == 1){
+            return pendingPermissions!.first!.name()
+        }
+        var nameList : [String] = []
+        pendingPermissions!.forEach{ perm in
+            nameList.append(perm.name())
+        }
+        return nameList.joined(separator: ", ")
+    }
+    
+    func requestPendingPermissions(){
+        if(pendingPermissions!.isEmpty){
+            onAuthorized()
+            return
+        }
+        pendingPermissions![0].requestAuth{ isAuthorized in
+            if(isAuthorized){
+                pendingPermissions!.remove(at: 0)
+                requestPendingPermissions()
+            }
+        }
     }
 }

--- a/Sources/TikiSdk/Ui/OfferFlow.swift
+++ b/Sources/TikiSdk/Ui/OfferFlow.swift
@@ -54,7 +54,12 @@ public struct OfferFlow: View{
                 .transition(.bottomSheet)
             }
             if(step == .endingError){
-                EndingError( pendingPermissions: getPendingPermissionsNames()
+                EndingError(
+                    pendingPermissions: $pendingPermissions,
+                    onAuthorized: {
+                        accept(activeOffer)
+                        goTo(.endingAccepted)
+                    }
                 ).asBottomSheet(
                     isShowing: isShowingBinding(.endingAccepted),
                     offset: $dragOffsetY,
@@ -154,12 +159,10 @@ public struct OfferFlow: View{
         if(pendingPermissions == nil || pendingPermissions!.isEmpty){
             return false
         }else{
-            var isPending = true
-            let pending = pendingPermissions![0]
-            pending.requestAuth{ isAuthorized in
-                if(isAuthorized){
-                    pendingPermissions!.remove(at: 0)
-                    isPending = isPendingPermission()
+            var isPending = false
+            pendingPermissions!.forEach{ permission in
+                if(!permission.isAuthorized()){
+                    isPending = true
                 }
             }
             return isPending
@@ -197,17 +200,4 @@ public struct OfferFlow: View{
         }
     }
     
-    func getPendingPermissionsNames() -> String{
-        if(pendingPermissions == nil || pendingPermissions!.isEmpty){
-            return "permissions"
-        }
-        if(pendingPermissions!.count == 1){
-            return pendingPermissions!.first!.name()
-        }
-        var nameList : [String] = []
-        pendingPermissions!.forEach{ perm in
-            nameList.append(perm.name())
-        }
-        return nameList.joined(separator: ", ")
-    }
 }


### PR DESCRIPTION
This PR updates the permissions check in Settings and OfferFlow to properly ask the user for each required permission on offer acceptance.

If permission has already been denied, the user is directed to the app settings to manually enable it. Additionally, the License Record will now only be executed after all required permissions have been accepted, ensuring that user data is not exposed without explicit consent.

Closes #189